### PR TITLE
add min and max line settings to editor

### DIFF
--- a/src/Blace.TestEditor/Pages/Index.razor
+++ b/src/Blace.TestEditor/Pages/Index.razor
@@ -7,16 +7,21 @@
 <button @onclick="CloseFile">Close</button>
 <button @onclick="SaveFile">Save</button>
 <button @onclick="ReloadFile">Reload</button>
+<input type="number" min="0" max="@MaxLinesValue" value="@MinLinesValue" @onchange="@((args) => SetMinLines(args))">
+<input type="number" min="@MinLinesValue" max="100" value="@MaxLinesValue" @onchange="@((args) => SetMaxLines(args))">
 
 <Blace.Components.Editor @ref="Editor" T="TestEditorFile" ShowSettings="true" />
 
 @code {
     public Editor<TestEditorFile> Editor { get; set; }
 
+    public int MinLinesValue = 5;
+    public int MaxLinesValue = 10;
+
     protected async Task AddFile()
     {
         var newFile = new TestEditorFile("file4");
-        await Editor.Open(newFile, new() { Syntax = Syntax.Python, Theme = Theme.Chrome });
+        await Editor.Open(newFile, new() { Syntax = Syntax.Python, Theme = Theme.Chrome, MinLines = MinLinesValue, MaxLines = MaxLinesValue });
     }
 
     protected async Task CloseFile()
@@ -32,5 +37,21 @@
     protected async Task ReloadFile()
     {
         await Editor.Reload();
+    }
+
+    protected async Task SetMinLines(ChangeEventArgs args)
+    {
+        int value = Convert.ToInt32(args.Value);
+        await Editor.SetMinLines(Convert.ToInt32(args.Value));
+        MinLinesValue = value;
+        StateHasChanged();
+    }
+
+    protected async Task SetMaxLines(ChangeEventArgs args)
+    {
+        int value = Convert.ToInt32(args.Value);
+        await Editor.SetMaxLines(Convert.ToInt32(args.Value));
+        MaxLinesValue = value;
+        StateHasChanged();
     }
 }

--- a/src/Blace/Components/Editor.razor.cs
+++ b/src/Blace/Components/Editor.razor.cs
@@ -27,6 +27,8 @@ namespace Blace.Components
         public bool ShowSettingsPanel { get; set; }
         public Theme Theme { get; set; }
         public Syntax Syntax { get; set; }
+        public int MinLines { get; set; }
+        public int MaxLines { get; set; }
 
         public async Task Open(T file, EditorOptions options = null)
         {
@@ -91,6 +93,22 @@ namespace Blace.Components
         {
             Theme = theme;
             await _editor?.SetTheme(Theme);
+        }
+
+        public async Task SetMinLines(int minLines)
+        {
+            if (_editor == null) return;
+
+            MinLines = minLines;
+            await _editor?.SetMinLines(minLines);
+        }
+
+        public async Task SetMaxLines(int maxLines)
+        {
+            if (_editor == null) return;
+
+            MaxLines = maxLines;
+            await _editor?.SetMaxLines(maxLines);
         }
 
         public async Task SyntaxChanged(Syntax syntax)

--- a/src/Blace/Editing/AceEditor.cs
+++ b/src/Blace/Editing/AceEditor.cs
@@ -20,6 +20,8 @@ namespace Blace.Editing
         public string Id { get; private set; }
         public Theme Theme { get => _options.Theme; }
         public Syntax Syntax { get => _options.Syntax; }
+        public int MinLines { get => _options.MinLines; }
+        public int MaxLines { get => _options.MaxLines; }
         public static string Value { get; private set; }
 
         public AceEditor(IJSRuntime js, string id, EditorOptions options, Func<string, Task> fileChanged = default, Func<bool, Task> save = null)
@@ -33,7 +35,7 @@ namespace Blace.Editing
 
         public async Task SetValue(string value)
         {
-            await _js.InvokeVoidAsync("ace_load", Id, GetTheme(Theme), GetSyntax(Syntax));
+            await _js.InvokeVoidAsync("ace_load", Id, GetTheme(Theme), GetSyntax(Syntax), MinLines, MaxLines);
 
             Value = string.IsNullOrWhiteSpace(value) ? string.Empty : value; ;
             await _js.InvokeVoidAsync("ace_set_value", Id, Value);
@@ -49,6 +51,18 @@ namespace Blace.Editing
         {
             await _js.InvokeVoidAsync("ace_set_mode", Id, GetSyntax(syntax));
             _options.Syntax = syntax;
+        }
+
+        public async Task SetMinLines(int minLines)
+        {
+            await _js.InvokeVoidAsync("ace_set_min_lines", Id, minLines);
+            _options.MinLines = minLines;
+        }
+
+        public async Task SetMaxLines(int maxLines)
+        {
+            await _js.InvokeVoidAsync("ace_set_max_lines", Id, maxLines);
+            _options.MaxLines = maxLines;
         }
 
         [JSInvokable]

--- a/src/Blace/Editing/EditorOptions.cs
+++ b/src/Blace/Editing/EditorOptions.cs
@@ -10,5 +10,7 @@ namespace Blace.Editing
     {
         public Theme Theme { get; set; }
         public Syntax Syntax { get; set; }
+        public int MinLines { get; set; } = 10;
+        public int MaxLines { get; set; }
     }
 }

--- a/src/Blace/wwwroot/ace/ace.js
+++ b/src/Blace/wwwroot/ace/ace.js
@@ -17,12 +17,15 @@
 
 assembly = "Blace";
 
-window.ace_load = function (id, theme, mode) {
+window.ace_load = function (id, theme, mode, min_lines, max_lines) {
     var editor = ace.edit(id);
     editor.setTheme(theme);
     editor.session.setMode(mode);
     editor.setShowPrintMargin(false);
-
+    editor.setOptions({
+        minLines: min_lines,
+        maxLines: max_lines
+    });
     editor.session.on("change", function () {
         DotNet.invokeMethodAsync(assembly, 'EditorValueChanged', editor.getValue());
     });
@@ -50,4 +53,18 @@ window.ace_set_mode = function (id, mode) {
 window.ace_set_value = function (id, value) {
     var editor = ace.edit(id);
     editor.setValue(value, 1);
+}
+
+window.ace_set_min_lines = function (id, min_lines) {
+    var editor = ace.edit(id);
+    editor.setOptions({
+        minLines: min_lines
+    });
+}
+
+window.ace_set_max_lines = function (id, max_lines) {
+    var editor = ace.edit(id);
+    editor.setOptions({
+        maxLines: max_lines
+    });
 }


### PR DESCRIPTION
Resizing the editor window was challenging. This change should allow the ability to dynamically adjust the size of the editor.

- Added MinLines to EditorOptions
- Added MaxLines to EditorOptions
- Added inputs on test project to allow for interaction with these settings.

😄 